### PR TITLE
MongoDBの接続先を読み込む環境変数を切り替え

### DIFF
--- a/lib/yonobot/mongodb.rb
+++ b/lib/yonobot/mongodb.rb
@@ -19,7 +19,7 @@ module Yonobot
     end
 
     def uri
-      ENV['MONGOLAB_URI']
+      ENV['DB_URI']
     end
 
     def client


### PR DESCRIPTION
mLabからAtrasにDBをマイグレーションするにあたって、`MONGOLAB_URI` が削除されるため別の環境変数へ切り替える
参考: https://mikan.github.io/2020/07/11/migrate-heroku-mlab-to-mongodb-atlas/